### PR TITLE
Handle missing Tesseract during PDF processing

### DIFF
--- a/Backend Python API/src/api/file_router.py
+++ b/Backend Python API/src/api/file_router.py
@@ -77,9 +77,9 @@ async def extract_and_insert_file(
                 extracted_data = extract_text_from_pdf_bytes(file_content, file.filename)
 
                 qdrant_documents = document_processor.process_file_for_qdrant(extracted_data, id_agent, id_file)
-                    
+
                 insertion_result = qdrant_client.insert_vectors(organization, id_agent, qdrant_documents)
-                            
+
                 return {
                     "message": "File processed and inserted successfully",
                     "file_info": {
@@ -91,11 +91,13 @@ async def extract_and_insert_file(
                         "insertion_result": insertion_result
                     }
                 }
-            
+
+            except RuntimeError as ocr_err:
+                raise HTTPException(status_code=503, detail=str(ocr_err))
             except ConnectionError as conn_err:
                 print(f"Qdrant connection error: {conn_err}")
                 raise HTTPException(
-                    status_code=503, 
+                    status_code=503,
                     detail=f"Qdrant service unavailable. Please check if Qdrant is running. Host: {config.QDRANT_HOST}:{config.QDRANT_PORT}"
                 )
             except Exception as qdrant_err:

--- a/Backend Python API/src/application/pdf_service.py
+++ b/Backend Python API/src/application/pdf_service.py
@@ -25,6 +25,13 @@ def _extract_file_type(filename: str) -> str:
     
         return "unknown"
 
+try:
+    pytesseract.get_tesseract_version()
+    _TESSERACT_AVAILABLE = True
+except pytesseract.TesseractNotFoundError:
+    _TESSERACT_AVAILABLE = False
+
+
 def extract_text_from_pdf_bytes(pdf_bytes: bytes, filename: str):
     """Extract text from PDF bytes.
 
@@ -45,6 +52,11 @@ def extract_text_from_pdf_bytes(pdf_bytes: bytes, filename: str):
     raw_pages: List[dict] = []
     # Helper: try OCR with a sequence of language fallbacks and handle errors
     def _ocr_with_fallback(pil_image) -> str:
+        if not _TESSERACT_AVAILABLE:
+            raise RuntimeError(
+                "Tesseract OCR is not installed or not available in PATH. "
+                "Install Tesseract to enable OCR for scanned PDFs."
+            )
         # Preferred languages to try (Portuguese then English, then default)
         candidates = ["por", "eng", None]
         last_exc: Exception | None = None


### PR DESCRIPTION
## Summary
- add a startup check to detect whether Tesseract OCR is available before attempting OCR
- return a clear HTTP 503 response when OCR cannot run due to a missing Tesseract binary

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df66f49bfc83299b4dba63b3d1981e