### PR TITLE
Use agent file ids for Gemelli document payload

### DIFF
--- a/Backend Dotnet API/src/Application/Interfaces/Services/IGemelliAIService.cs
+++ b/Backend Dotnet API/src/Application/Interfaces/Services/IGemelliAIService.cs
@@ -1,5 +1,5 @@
+using System.Collections.Generic;
 using ErrorOr;
-
 
 namespace Application.Interfaces.Services;
 
@@ -17,14 +17,17 @@ public interface IGemelliAIService
 
 public class GemelliAIChatRequest
 {
+    public string? IdSession { get; set; }
+    public string IdAgent { get; set; } = string.Empty;
     public string Message { get; set; } = string.Empty;
-    public string Module { get; set; }
+    public string Module { get; set; } = string.Empty;
     public string Organization { get; set; } = string.Empty;
     public string UserName { get; set; } = string.Empty;
     public string UserEmail { get; set; } = string.Empty;
     public string AgentType { get; set; } = string.Empty;
+    public Dictionary<string, string>? Preferences { get; set; }
+    public List<string> Documents { get; set; } = new();
     public List<(int Role, string Content)> ChatHistory { get; set; } = new();
-    public List<(string Name, string Content)> Files { get; set; } = new();
 }
 
 public class GemelliAIChatResponse

--- a/Backend Dotnet API/src/Infrastructure/Contracts/GemelliAI/Request/ChatRequest.cs
+++ b/Backend Dotnet API/src/Infrastructure/Contracts/GemelliAI/Request/ChatRequest.cs
@@ -1,10 +1,16 @@
-using Domain.Enums;
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Infrastructure.Contracts.GemelliAI.Request;
 
 public class ChatRequest
 {
+    [JsonPropertyName("id_session")]
+    public string? IdSession { get; set; }
+
+    [JsonPropertyName("id_agent")]
+    public string IdAgent { get; set; } = string.Empty;
+
     [JsonPropertyName("message")]
     public string Message { get; set; } = string.Empty;
 
@@ -17,11 +23,14 @@ public class ChatRequest
     [JsonPropertyName("user")]
     public ChatUser User { get; set; } = new();
 
+    [JsonPropertyName("preferences")]
+    public Dictionary<string, string>? Preferences { get; set; }
+
     [JsonPropertyName("chat_history")]
     public List<ChatHistoryItem> ChatHistory { get; set; } = new();
 
-    [JsonPropertyName("files")]
-    public List<ChatFile> Files { get; set; } = new();
+    [JsonPropertyName("documents")]
+    public List<string> Documents { get; set; } = new();
 
     [JsonPropertyName("agent_type")]
     public string AgentType { get; set; } = string.Empty;
@@ -40,15 +49,6 @@ public class ChatHistoryItem
 {
     [JsonPropertyName("role")]
     public int Role { get; set; }
-
-    [JsonPropertyName("content")]
-    public string Content { get; set; } = string.Empty;
-}
-
-public class ChatFile
-{
-    [JsonPropertyName("name")]
-    public string Name { get; set; } = string.Empty;
 
     [JsonPropertyName("content")]
     public string Content { get; set; } = string.Empty;

--- a/Backend Dotnet API/src/Infrastructure/Services/GemelliAIService.cs
+++ b/Backend Dotnet API/src/Infrastructure/Services/GemelliAIService.cs
@@ -5,6 +5,7 @@ using Infrastructure.Contracts.GemelliAI.Response;
 using Infrastructure.HttpClient.GemelliAI;
 using Microsoft.Extensions.Logging;
 using Refit;
+using System.Linq;
 
 namespace Infrastructure.Services;
 
@@ -29,8 +30,10 @@ public class GemelliAIService : IGemelliAIService
         {
             var apiRequest = new ChatRequest
             {
+                IdSession = request.IdSession,
+                IdAgent = request.IdAgent,
                 Message = request.Message,
-                Module = request.Module.ToString(),
+                Module = request.Module,
                 Organization = request.Organization,
                 User = new ChatUser
                 {
@@ -38,11 +41,8 @@ public class GemelliAIService : IGemelliAIService
                     Email = request.UserEmail
                 },
                 AgentType = request.AgentType,
-                Files = request.Files.Select(f => new ChatFile
-                {
-                    Name = f.Name,
-                    Content = f.Content
-                }).ToList(),
+                Preferences = request.Preferences,
+                Documents = request.Documents,
                 ChatHistory = request.ChatHistory.Select(h => new ChatHistoryItem
                 {
                     Role = h.Role,


### PR DESCRIPTION
## Summary
- gather the Gemelli document identifiers from the files associated with the agent when sending chat requests

## Testing
- dotnet build GemelliAPI.sln *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df660fb9b88329baae5a910f340cb0