### PR TITLE
Add default preferences to chat requests

### DIFF
--- a/Backend Dotnet API/src/Application/Handlers/Chat/FirstMessage/FirstMessageHandler.cs
+++ b/Backend Dotnet API/src/Application/Handlers/Chat/FirstMessage/FirstMessageHandler.cs
@@ -92,7 +92,8 @@ public class FirstMessageHandler : BaseHandler
             UserName = user.Name,
             UserEmail = user.Email,
             AgentType = "basic",
-            Documents = documentsForService
+            Documents = documentsForService,
+            Preferences = CreateDefaultPreferences()
         }, cancellationToken);
 
         if (chatResult.IsError)
@@ -140,4 +141,12 @@ public class FirstMessageHandler : BaseHandler
             SessionId = session.Id.ToString()
         };
     }
+
+    private static Dictionary<string, string> CreateDefaultPreferences() => new()
+    {
+        ["agent-personality"] = "Very formal",
+        ["use-emoji"] = "Never",
+        ["response-type"] = "Concise",
+        ["refer-to-user-as"] = "Mr.,Mrs."
+    };
 }

--- a/Backend Dotnet API/src/Application/Handlers/Chat/SendMessage/SendChatMessageHandler.cs
+++ b/Backend Dotnet API/src/Application/Handlers/Chat/SendMessage/SendChatMessageHandler.cs
@@ -90,11 +90,6 @@ public class SendChatMessageHandler : BaseHandler
             .Select(file => file.Id.ToString())
             .ToList() ?? new List<string>();
 
-        var historyForService = session.ChatHistory
-            .OrderBy(h => h.CreatedAt)
-            .Select(h => (Role: h.Role == RoleChat.User ? 0 : 1, Content: h.Content))
-            .ToList();
-
         ErrorOr<GemelliAIChatResponse> chatResult = await _gemelliAIService.ChatAsync(new GemelliAIChatRequest
         {
             IdSession = session.Id.ToString(),
@@ -106,7 +101,7 @@ public class SendChatMessageHandler : BaseHandler
             UserEmail = user.Email,
             AgentType = "basic",
             Documents = documentsForService,
-            ChatHistory = historyForService
+            Preferences = CreateDefaultPreferences()
         }, cancellationToken);
 
         if (chatResult.IsError)
@@ -146,4 +141,12 @@ public class SendChatMessageHandler : BaseHandler
             MessageResponse = chatResult.Value.MessageResponse
         };
     }
+
+    private static Dictionary<string, string> CreateDefaultPreferences() => new()
+    {
+        ["agent-personality"] = "Very formal",
+        ["use-emoji"] = "Never",
+        ["response-type"] = "Concise",
+        ["refer-to-user-as"] = "Mr.,Mrs."
+    };
 }


### PR DESCRIPTION
## Summary
- add default chat preferences to both first and follow-up message handlers
- stop sending prior chat history to the chat service on follow-up messages

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68df6bbbe2b88329afdddba6438b8460