### PR TITLE
Configure Gemelli AI token via settings

### DIFF
--- a/Backend Dotnet API/src/API/appsettings.Development.json
+++ b/Backend Dotnet API/src/API/appsettings.Development.json
@@ -65,6 +65,7 @@
     "BasePath": "../Infrastructure/EmailTemplates"
   },
   "GemelliAISettings": {
-    "BaseUrl": "http://komvosmind_ai:8000"
+    "BaseUrl": "http://komvosmind_ai:8000",
+    "Token": ""
   }
 }

--- a/Backend Dotnet API/src/API/appsettings.json
+++ b/Backend Dotnet API/src/API/appsettings.json
@@ -61,6 +61,7 @@
     "BasePath": "../Infrastructure/EmailTemplates"
   },
   "GemelliAISettings": {
-    "BaseUrl": "http://komvosmind_ai:8000"
+    "BaseUrl": "http://komvosmind_ai:8000",
+    "Token": ""
   }
 }

--- a/Backend Dotnet API/src/Application/AppConfig/GemelliAISettings.cs
+++ b/Backend Dotnet API/src/Application/AppConfig/GemelliAISettings.cs
@@ -5,4 +5,5 @@ public class GemelliAISettings
     public string BaseUrl { get; set; } = string.Empty;
     public int TimeoutSeconds { get; set; } = 90;
     public int RetryCount { get; set; } = 3;
+    public string Token { get; set; } = string.Empty;
 }

--- a/Backend Dotnet API/src/Infrastructure/Extensions/InfrastructureExtensions.cs
+++ b/Backend Dotnet API/src/Infrastructure/Extensions/InfrastructureExtensions.cs
@@ -50,6 +50,9 @@ public static class InfrastructureExtensions
         IConfigurationSection GemelliApiSection = configuration.GetSection(nameof(GemelliApiSettings));
         services.Configure<GemelliApiSettings>(GemelliApiSection);
 
+        IConfigurationSection gemelliAISection = configuration.GetSection(nameof(GemelliAISettings));
+        services.Configure<GemelliAISettings>(gemelliAISection);
+
         IConfigurationSection templateEmailSettingsSection = configuration.GetSection(nameof(TemplateEmailSettings));
         services.Configure<TemplateEmailSettings>(templateEmailSettingsSection);
 


### PR DESCRIPTION
## Summary
- load Gemelli AI token from configuration and inject it through the Refit handler for chat and file calls
- bind GemelliAISettings options and add the token placeholder to appsettings files for local and default environments

## Testing
- Not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68df6d8dc2f48329a3502df8aec0b630