### PR TITLE
Add chat session external metadata and title support

### DIFF
--- a/Backend Dotnet API/src/Application/DTOs/Agent/AgentByIdResponse.cs
+++ b/Backend Dotnet API/src/Application/DTOs/Agent/AgentByIdResponse.cs
@@ -39,7 +39,10 @@ public class FilePageResponse
 
 public class AgentChatSessions
 {
+    public Guid Id { get; set; }
     public string? MessageResponse { get; set; }
+    public string? ExternalSessionId { get; set; }
+    public string? Title { get; set; }
 }
 
 public class AgentChatHistory

--- a/Backend Dotnet API/src/Application/DTOs/Chat/FirstMessageResponse.cs
+++ b/Backend Dotnet API/src/Application/DTOs/Chat/FirstMessageResponse.cs
@@ -4,4 +4,6 @@ public class FirstMessageResponse
 {
     public string MessageResponse { get; set; } = string.Empty;
     public string SessionId { get; set; } = string.Empty;
+    public string ExternalSessionId { get; set; } = string.Empty;
+    public string Title { get; set; } = string.Empty;
 }

--- a/Backend Dotnet API/src/Application/Interfaces/Services/IGemelliAIService.cs
+++ b/Backend Dotnet API/src/Application/Interfaces/Services/IGemelliAIService.cs
@@ -11,6 +11,10 @@ public interface IGemelliAIService
         GemelliAIChatRequest request,
         CancellationToken cancellationToken = default);
 
+    Task<ErrorOr<string>> GetChatTitleAsync(
+        string idSession,
+        CancellationToken cancellationToken = default);
+
 
     Task<ErrorOr<GemelliAIFileResponse>> FileAsync(
         GemelliAIFileRequest request,

--- a/Backend Dotnet API/src/Application/Mappings/MapConfig.cs
+++ b/Backend Dotnet API/src/Application/Mappings/MapConfig.cs
@@ -47,6 +47,9 @@ public static class MapConfig
 
         // AgentChatSessions
         config.NewConfig<ChatSession, AgentChatSessions>()
+            .Map(dest => dest.Id, src => src.Id)
+            .Map(dest => dest.ExternalSessionId, src => src.IdSession)
+            .Map(dest => dest.Title, src => src.Title)
             .Map(dest => dest.MessageResponse, src => src.ChatHistory.LastOrDefault() != null ? src.ChatHistory.LastOrDefault()!.Content : null);
 
         // AgentChatHistory

--- a/Backend Dotnet API/src/Domain/Entities/ChatSession.cs
+++ b/Backend Dotnet API/src/Domain/Entities/ChatSession.cs
@@ -8,6 +8,8 @@ public sealed class ChatSession : BaseEntity
     public Agent Agent { get; set; }
     public int TotalInteractions { get; set; }
     public string IdUser { get; set; }
+    public string? IdSession { get; set; }
+    public string? Title { get; set; }
     public DateTime LastSendDate { get; set; }
     public IEnumerable<ChatHistory> ChatHistory => _chatsHistories;
     private readonly List<ChatHistory> _chatsHistories =

--- a/Backend Dotnet API/src/Infrastructure/HttpClient/GemelliAI/IGemelliAIClient.cs
+++ b/Backend Dotnet API/src/Infrastructure/HttpClient/GemelliAI/IGemelliAIClient.cs
@@ -18,4 +18,9 @@ public interface IGemelliAIClient
         string organization,
         string id_agent,
         CancellationToken cancellationToken = default);
+
+    [Get("/chat/title/{id_session}")]
+    Task<string> GetChatTitleAsync(
+        string id_session,
+        CancellationToken cancellationToken = default);
 }

--- a/Backend Dotnet API/src/Infrastructure/Migrations/Tenant/20251001000000_AddChatSessionExternalFields.Designer.cs
+++ b/Backend Dotnet API/src/Infrastructure/Migrations/Tenant/20251001000000_AddChatSessionExternalFields.Designer.cs
@@ -4,6 +4,7 @@ using Infrastructure.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Infrastructure.Migrations.Tenant
 {
     [DbContext(typeof(TenantDbContext))]
-    partial class TenantDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251001000000_AddChatSessionExternalFields")]
+    partial class AddChatSessionExternalFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Backend Dotnet API/src/Infrastructure/Migrations/Tenant/20251001000000_AddChatSessionExternalFields.cs
+++ b/Backend Dotnet API/src/Infrastructure/Migrations/Tenant/20251001000000_AddChatSessionExternalFields.cs
@@ -1,0 +1,43 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations.Tenant;
+
+    /// <inheritdoc />
+    public partial class AddChatSessionExternalFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "IdSession",
+                table: "ChatSessions",
+                type: "varchar(400)",
+                unicode: false,
+                maxLength: 200,
+                nullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Title",
+                table: "ChatSessions",
+                type: "varchar(400)",
+                unicode: false,
+                maxLength: 400,
+                nullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IdSession",
+                table: "ChatSessions");
+
+            migrationBuilder.DropColumn(
+                name: "Title",
+                table: "ChatSessions");
+        }
+    }

--- a/Backend Dotnet API/src/Infrastructure/ModelConfig/Tenant/ChatSessionEntityConfig.cs
+++ b/Backend Dotnet API/src/Infrastructure/ModelConfig/Tenant/ChatSessionEntityConfig.cs
@@ -20,9 +20,15 @@ public sealed class ChatSessionConfiguration : IEntityTypeConfiguration<ChatSess
 
         builder.Property(cs => cs.IdAgent)
             .IsRequired();
-        
+
         builder.Property(cs => cs.IdUser)
             .IsRequired();
+
+        builder.Property(cs => cs.IdSession)
+            .HasMaxLength(200);
+
+        builder.Property(cs => cs.Title)
+            .HasMaxLength(400);
 
         builder.HasOne(cs => cs.Agent)
             .WithMany(a => a.Chats)

--- a/Backend Dotnet API/src/Infrastructure/Services/GemelliAIService.cs
+++ b/Backend Dotnet API/src/Infrastructure/Services/GemelliAIService.cs
@@ -112,4 +112,26 @@ public class GemelliAIService : IGemelliAIService
             return Error.Failure("IA.File.Error", "Erro inesperado ao processar requisição");
         }
     }
+
+    public async Task<ErrorOr<string>> GetChatTitleAsync(
+        string idSession,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            string title = await _client.GetChatTitleAsync(idSession, cancellationToken);
+
+            return title ?? string.Empty;
+        }
+        catch (ApiException ex)
+        {
+            _logger.LogError(ex, "Erro ao obter título do chat - Status: {StatusCode}", ex.StatusCode);
+            return Error.Failure("IA.Chat.Title.Error", $"Erro na API: {ex.Message}");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Erro inesperado ao obter título do chat");
+            return Error.Failure("IA.Chat.Title.Error", "Erro inesperado ao processar requisição");
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- extend chat sessions and related projections with external session ID and title metadata
- call the Gemelli AI title endpoint after the first chat exchange and persist the values
- ensure follow-up messages reuse the stored external session ID and refresh the title when needed, including a new migration for the schema changes

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e31b2f12c88329b77b8582b542ac7f