### PR TITLE
Align file creation IDs with Gemelli AI

### DIFF
--- a/Backend Dotnet API/src/Application/Handlers/File/Create/CreateFileHandler.cs
+++ b/Backend Dotnet API/src/Application/Handlers/File/Create/CreateFileHandler.cs
@@ -5,6 +5,7 @@ using Authentication.Models;
 using Domain.Enums;
 using Domain.Errors;
 using ErrorOr;
+using System;
 
 namespace Application.Handlers.File.Create;
 
@@ -54,12 +55,15 @@ public class CreateFileHandler : BaseHandler
             return FileErrors.NotFound; 
         }
 
+        Guid fileId = request.IdFile ?? Guid.NewGuid();
+
         ErrorOr<GemelliAIFileResponse> documentResult = await _gemelliAIService.FileAsync(
-            new GemelliAIFileRequest { 
-                FileStream = request.Arquivo.OpenReadStream(), 
+            new GemelliAIFileRequest {
+                FileStream = request.Arquivo.OpenReadStream(),
                 FileName = request.Arquivo.FileName,
                 Organization = request.Organization ?? string.Empty,
-                IdAgent = request.IdAgent ?? string.Empty
+                IdAgent = request.IdAgent ?? string.Empty,
+                IdFile = fileId.ToString()
             },
             cancellationToken);
 
@@ -77,6 +81,7 @@ public class CreateFileHandler : BaseHandler
 
         await _fileRepository.AddAsync(new Domain.Entities.File()
         {
+            Id = fileId,
             FileName = documentResult.Value.FileName,
             Module = module,
             Resume = documentResult.Value.Resume,

--- a/Backend Dotnet API/src/Application/Handlers/File/Create/CreateFileRequest.cs
+++ b/Backend Dotnet API/src/Application/Handlers/File/Create/CreateFileRequest.cs
@@ -1,12 +1,14 @@
 using FluentValidation;
 using Microsoft.AspNetCore.Http;
+using System;
 
 namespace Application.Handlers.File.Create;
 
 public record CreateFileRequest(
     IFormFile Arquivo,
     string Organization,
-    string IdAgent
+    string IdAgent,
+    Guid? IdFile
 );
 
 public class CreateFileRequestValidator : AbstractValidator<CreateFileRequest>

--- a/Backend Dotnet API/src/Application/Interfaces/Services/IGemelliAIService.cs
+++ b/Backend Dotnet API/src/Application/Interfaces/Services/IGemelliAIService.cs
@@ -72,4 +72,5 @@ public class GemelliAIFileRequest
     public string FileName { get; set; } = string.Empty;
     public string Organization { get; set; } = string.Empty;
     public string IdAgent { get; set; } = string.Empty;
+    public string IdFile { get; set; } = string.Empty;
 }

--- a/Backend Dotnet API/src/Infrastructure/HttpClient/GemelliAI/IGemelliAIClient.cs
+++ b/Backend Dotnet API/src/Infrastructure/HttpClient/GemelliAI/IGemelliAIClient.cs
@@ -12,11 +12,12 @@ public interface IGemelliAIClient
         CancellationToken cancellationToken = default);
 
     [Multipart]
-    [Post("/file/{organization}/{id_agent}")]
+    [Post("/file/{organization}/{id_agent}/{id_file}")]
     Task<FileProcessingResponse> FileAsync(
         [AliasAs("file")] StreamPart file,
         string organization,
         string id_agent,
+        string id_file,
         CancellationToken cancellationToken = default);
 
     [Get("/chat/title/{id_session}")]

--- a/Backend Dotnet API/src/Infrastructure/Services/GemelliAIService.cs
+++ b/Backend Dotnet API/src/Infrastructure/Services/GemelliAIService.cs
@@ -93,7 +93,12 @@ public class GemelliAIService : IGemelliAIService
         {
             var filePart = new StreamPart(request.FileStream, request.FileName, "application/octet-stream");
 
-            FileProcessingResponse response = await _client.FileAsync(filePart, request.Organization ?? string.Empty, request.IdAgent ?? string.Empty, cancellationToken);
+            FileProcessingResponse response = await _client.FileAsync(
+                filePart,
+                request.Organization ?? string.Empty,
+                request.IdAgent ?? string.Empty,
+                request.IdFile ?? string.Empty,
+                cancellationToken);
 
             return new GemelliAIFileResponse
             {


### PR DESCRIPTION
## Summary
- add an IdFile field to CreateFileRequest and reuse it when creating files
- propagate the file identifier through the Gemelli AI request and client so the API call uses /file/{organization}/{id_agent}/{id_file}
- persist the shared identifier on the Domain.Entities.File to keep Gemelli AI and the database in sync

## Testing
- dotnet build *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e31db9aee48329a63a074dafdb1b78