### PR TITLE
Fix Gemelli document summary usage model and cleanup Refit registration

### DIFF
--- a/Backend Dotnet API/src/API/Program.cs
+++ b/Backend Dotnet API/src/API/Program.cs
@@ -67,7 +67,7 @@ builder
     .AddAuthenticationServices()
     .AddRepositoriesServices()
     .AddInfrastructureServices(builder.Configuration)
-    .AddRefitServices(builder.Configuration);
+    .AddRefitServices();
 
 WebApplication app = builder.Build();
 

--- a/Backend Dotnet API/src/Infrastructure/Contracts/GemelliAI/Response/DocumentSummaryResponse.cs
+++ b/Backend Dotnet API/src/Infrastructure/Contracts/GemelliAI/Response/DocumentSummaryResponse.cs
@@ -14,5 +14,17 @@ public class DocumentSummaryResponse
     public string ResumeFile { get; set; } = string.Empty;
 
     [JsonPropertyName("usage")]
-    public Usage Usage { get; set; } = new();
+    public DocumentSummaryUsage Usage { get; set; } = new();
+}
+
+public class DocumentSummaryUsage
+{
+    [JsonPropertyName("input_tokens")]
+    public int InputTokens { get; set; }
+
+    [JsonPropertyName("output_tokens")]
+    public int OutputTokens { get; set; }
+
+    [JsonPropertyName("total_tokens")]
+    public int TotalTokens { get; set; }
 }

--- a/Backend Dotnet API/src/Infrastructure/Extensions/InfrastructureExtensions.cs
+++ b/Backend Dotnet API/src/Infrastructure/Extensions/InfrastructureExtensions.cs
@@ -98,7 +98,7 @@ public static class InfrastructureExtensions
         return services;
     }
 
-    public static IServiceCollection AddRefitServices(this IServiceCollection services, IConfiguration configuration)
+    public static IServiceCollection AddRefitServices(this IServiceCollection services)
     {
         services.AddTransient<AuthHeaderHandler>();
 


### PR DESCRIPTION
## Summary
- define a concrete usage model for Gemelli document summary responses so the contract compiles
- remove the unused configuration parameter from the Refit registration helper and update the Program bootstrapper

## Testing
- not run (dotnet SDK is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e320143a1c8329b50d88e301a747fa