### PR TITLE
Include session title in session history responses

### DIFF
--- a/Backend Dotnet API/src/Application/DTOs/Session/SessionResponse.cs
+++ b/Backend Dotnet API/src/Application/DTOs/Session/SessionResponse.cs
@@ -4,4 +4,5 @@ public class SessionResponse
 {
    public string? SessionId { get; set; }
    public string? LastSendDate { get; set; }
+   public string? Title { get; set; }
 }

--- a/Backend Dotnet API/src/Application/Handlers/Session/SearchByAgentId/SearchSessionByIdAgentHandler.cs
+++ b/Backend Dotnet API/src/Application/Handlers/Session/SearchByAgentId/SearchSessionByIdAgentHandler.cs
@@ -60,7 +60,8 @@ public class SearchSessionByIdAgentHandler : BaseHandler
             .Select(s => new SessionResponse
             {
                 SessionId = s.Id.ToString(),
-                LastSendDate = s.LastSendDate.ToString(CultureInfo.InvariantCulture)
+                LastSendDate = s.LastSendDate.ToString(CultureInfo.InvariantCulture),
+                Title = s.Title
             })
             .ToList();
 


### PR DESCRIPTION
## Summary
- add the session title to the session history API response DTO
- populate the new title field when mapping chat sessions for agent/user history results

## Testing
- dotnet build *(fails: `dotnet: command not found` in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3cbc56fd083298541c5bd48584da5