### PR TITLE
Fix session list title display

### DIFF
--- a/Frontend nextjs/src/app/(app)/agents/[id]/chat/_components/chat-session-list.tsx
+++ b/Frontend nextjs/src/app/(app)/agents/[id]/chat/_components/chat-session-list.tsx
@@ -28,7 +28,7 @@ export function ChatSessionList({
       <div className="flex-1 overflow-y-auto space-y-1 p-2">
         {sessions.map((s) => (
           <div
-            key={s.sessionName}
+            key={s.sessionId}
             onClick={() => onSelect(s.sessionId)}
             className={cn(
               "cursor-pointer rounded-md p-2 text-sm hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
@@ -36,7 +36,7 @@ export function ChatSessionList({
                 "bg-sidebar-accent text-sidebar-accent-foreground"
             )}
           >
-            <div className="font-medium truncate">{s.sessionId}</div>
+            <div className="font-medium truncate">{s.title}</div>
             <div className="text-xs opacity-60">
               {new Date(s.lastSendDate).toLocaleString()}
             </div>

--- a/Frontend nextjs/src/app/(app)/agents/[id]/chat/_hooks/use-agent-chat.hook.ts
+++ b/Frontend nextjs/src/app/(app)/agents/[id]/chat/_hooks/use-agent-chat.hook.ts
@@ -57,7 +57,7 @@ export function useAgentChat(
               sessionId: res.sessionId,
               lastSendDate: now,
               totalInteractions: "1",
-              sessionName: "Novo Chat", // sessionName: res.session,
+              title: "Novo Chat",
             },
             ...old,
           ]

--- a/Frontend nextjs/src/types/schemas/chat.schema.ts
+++ b/Frontend nextjs/src/types/schemas/chat.schema.ts
@@ -20,7 +20,7 @@ export type ChatHistoryItem = z.infer<typeof ChatHistoryItemSchema>;
 export const SessionHistorySchema = z.object({
   sessionId: z.string(),
   lastSendDate: z.string(),
-  sessionName: z.string(),
+  title: z.string(),
   totalInteractions: z.string().optional(),
 });
 


### PR DESCRIPTION
## Summary
- update session history schema to read the title returned by the API
- ensure newly created sessions populate a default title
- show the session title in the chat session list instead of the identifier

## Testing
- npm run lint *(fails: missing @eslint/eslintrc package in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3eec36a0c8329b6c9302ed861fe94