### PR TITLE
Remove Gemelli AI dependency from file upload flow

### DIFF
--- a/Backend Dotnet API/src/Application/Handlers/File/Create/CreateFileRequest.cs
+++ b/Backend Dotnet API/src/Application/Handlers/File/Create/CreateFileRequest.cs
@@ -6,8 +6,6 @@ namespace Application.Handlers.File.Create;
 
 public record CreateFileRequest(
     IFormFile Arquivo,
-    string Organization,
-    string IdAgent,
     Guid? IdFile
 );
 


### PR DESCRIPTION
## Summary
- drop the organization and agent fields from the file creation request contract
- stop invoking the Gemelli AI service when uploading a file and persist metadata from the blob upload response only

## Testing
- `dotnet test` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e404ae08408329be7af205bf420544