### PR TITLE
Add Qdrant vector deletion endpoint

### DIFF
--- a/Backend Python API/README.md
+++ b/Backend Python API/README.md
@@ -93,3 +93,24 @@ Resposta esperada:
   "file-content": "Texto extraído do documento..."
 }
 ```
+
+## Rota `/file/{organization}/{id_agent}/{id_file}` (DELETE)
+
+Remove todos os vetores associados a um arquivo específico do Qdrant.
+
+```bash
+curl -X DELETE http://localhost:8000/file/minha-org/agent-123/file-456
+```
+
+Resposta esperada:
+
+```json
+{
+  "status": "completed",
+  "deleted_count": 42,
+  "operation_id": 12345
+}
+```
+
+> O campo `deleted_count` reflete a quantidade estimada de vetores removidos
+> do Qdrant com base no filtro aplicado.

--- a/Backend Python API/requirements.txt
+++ b/Backend Python API/requirements.txt
@@ -28,3 +28,4 @@ sentence-transformers
 numpy
 openai
 langchain-openai
+pytest

--- a/Backend Python API/src/domain/file.py
+++ b/Backend Python API/src/domain/file.py
@@ -1,0 +1,15 @@
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class FileDeletionResponse(BaseModel):
+    """Representa a resposta padronizada para remoção de vetores de um arquivo."""
+
+    status: str = Field(..., description="Status da operação retornado pelo Qdrant")
+    deleted_count: int = Field(0, ge=0, description="Quantidade de vetores removidos do Qdrant")
+    operation_id: Optional[int] = Field(
+        default=None,
+        description="Identificador da operação retornado pelo Qdrant"
+    )
+

--- a/Backend Python API/src/infrastructure/qdrant/qdrant_service.py
+++ b/Backend Python API/src/infrastructure/qdrant/qdrant_service.py
@@ -23,6 +23,22 @@ class QdrantService:
     def delete_vectors(self, tenant_id: str, collection_name: str, point_ids: List[int], wait: bool = True):
         return self.client.delete_vectors(tenant_id, collection_name, point_ids, wait)
 
+    def delete_vectors_by_file(
+        self,
+        tenant_id: str,
+        collection_name: str,
+        id_agent: str,
+        id_file: str,
+        wait: bool = True
+    ):
+        return self.client.delete_vectors_by_filter(
+            tenant_id,
+            collection_name,
+            id_agent,
+            id_file,
+            wait
+        )
+
     def delete_collection(self, tenant_id: str, collection_name: str):
         return self.client.delete_collection(tenant_id, collection_name)
 

--- a/Backend Python API/tests/api/test_file_router.py
+++ b/Backend Python API/tests/api/test_file_router.py
@@ -1,0 +1,56 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.file_router import router
+
+
+def create_app():
+    app = FastAPI()
+    app.include_router(router)
+    return app
+
+
+def test_delete_file_vectors_success(monkeypatch):
+    class DummyService:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def delete_vectors_by_file(self, tenant_id, collection_name, id_agent, id_file):
+            return {
+                "status": "completed",
+                "deleted_count": 3,
+                "operation_id": 123
+            }
+
+    monkeypatch.setattr("src.api.file_router.QdrantService", DummyService)
+
+    app = create_app()
+    client = TestClient(app)
+
+    response = client.delete("/file/org-1/agent-2/file-3")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "completed",
+        "deleted_count": 3,
+        "operation_id": 123
+    }
+
+
+def test_delete_file_vectors_connection_error(monkeypatch):
+    class DummyService:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def delete_vectors_by_file(self, *args, **kwargs):
+            raise ConnectionError("boom")
+
+    monkeypatch.setattr("src.api.file_router.QdrantService", DummyService)
+
+    app = create_app()
+    client = TestClient(app)
+
+    response = client.delete("/file/org-1/agent-2/file-3")
+
+    assert response.status_code == 503
+    assert "boom" in response.json()["detail"]

--- a/Backend Python API/tests/conftest.py
+++ b/Backend Python API/tests/conftest.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+
+class _DummyChatGroq:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def invoke(self, *args, **kwargs):
+        return SimpleNamespace(content="")
+
+
+def _dummy_camelot_read_pdf(*args, **kwargs):
+    return SimpleNamespace(n=0)
+
+
+if "langchain_groq" not in sys.modules:
+    sys.modules["langchain_groq"] = SimpleNamespace(ChatGroq=_DummyChatGroq)
+
+if "camelot" not in sys.modules:
+    sys.modules["camelot"] = SimpleNamespace(read_pdf=_dummy_camelot_read_pdf)

--- a/Backend Python API/tests/infrastructure/qdrant/test_qdrant_repository.py
+++ b/Backend Python API/tests/infrastructure/qdrant/test_qdrant_repository.py
@@ -1,0 +1,52 @@
+from unittest.mock import MagicMock
+
+import pytest
+from qdrant_client.http import models
+
+from src.infrastructure.qdrant.qdrant_repository import QdrantRepository
+
+
+@pytest.fixture()
+def repository(monkeypatch):
+    repo = QdrantRepository.__new__(QdrantRepository)
+    repo.host = "localhost"
+    repo.port = 6333
+    repo.api_key = None
+    repo.client = MagicMock()
+
+    monkeypatch.setattr(repo, "collection_exists", lambda tenant_id, collection_name: True)
+
+    return repo
+
+
+def test_delete_vectors_by_filter_builds_payload_filter(repository):
+    repository.client.count.return_value = models.CountResult(count=5)
+    repository.client.delete.return_value = models.UpdateResult(
+        status=models.UpdateStatus.COMPLETED,
+        operation_id=99
+    )
+
+    result = repository.delete_vectors_by_filter(
+        tenant_id="TenantA",
+        collection_name="CollectionB",
+        id_agent="agent-123",
+        id_file="file-456"
+    )
+
+    repository.client.count.assert_called_once()
+    repository.client.delete.assert_called_once()
+
+    delete_kwargs = repository.client.delete.call_args.kwargs
+
+    assert delete_kwargs["collection_name"] == "tenanta_collectionb"
+    assert delete_kwargs["wait"] is True
+
+    payload_filter = delete_kwargs["filter"]
+    assert isinstance(payload_filter, models.Filter)
+    keys = {condition.key for condition in payload_filter.must}
+    assert "metadata.id_agent" in keys
+    assert "metadata.id_file" in keys
+
+    assert result["status"] == models.UpdateStatus.COMPLETED.value
+    assert result["operation_id"] == 99
+    assert result["deleted_count"] == 5

--- a/Backend Python API/tests/infrastructure/services/test_qdrant_service.py
+++ b/Backend Python API/tests/infrastructure/services/test_qdrant_service.py
@@ -1,0 +1,35 @@
+from unittest.mock import MagicMock
+
+from src.infrastructure.qdrant.qdrant_service import QdrantService
+
+
+def test_delete_vectors_by_file_uses_repository(monkeypatch):
+    repository_mock = MagicMock()
+    repository_mock.delete_vectors_by_filter.return_value = {
+        "status": "completed",
+        "deleted_count": 2,
+        "operation_id": 77
+    }
+
+    service = QdrantService.__new__(QdrantService)
+    service.client = repository_mock
+
+    result = service.delete_vectors_by_file(
+        tenant_id="Tenant",
+        collection_name="Collection",
+        id_agent="agent",
+        id_file="file"
+    )
+
+    repository_mock.delete_vectors_by_filter.assert_called_once_with(
+        "Tenant",
+        "Collection",
+        "agent",
+        "file",
+        True
+    )
+    assert result == {
+        "status": "completed",
+        "deleted_count": 2,
+        "operation_id": 77
+    }


### PR DESCRIPTION
## Summary
- add repository support for deleting vectors by agent and file filter
- expose new deletion method through the Qdrant service and FastAPI router with structured response
- document the DELETE route, add pytest dependency, and cover repository, service, and route with tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e40aff65548329a73995c8e457f9c6