### PR TITLE
Integrate file summary generation

### DIFF
--- a/Backend Dotnet API/src/Application/DTOs/File/FileResponse.cs
+++ b/Backend Dotnet API/src/Application/DTOs/File/FileResponse.cs
@@ -7,6 +7,7 @@ public class FileResponse
 {
     public Guid Id { get; set; }
     public string FileName { get; set; }
+    public string? GeneratedName { get; set; }
     public string UrlFile { get; set; }
     public IEnumerable<PageResponse>? Pages { get; set; }
     public IEnumerable<AgentResponse>? Agents { get; set; }

--- a/Backend Dotnet API/src/Application/Handlers/File/AttachToAgent/AttachToAgentFileHandler.cs
+++ b/Backend Dotnet API/src/Application/Handlers/File/AttachToAgent/AttachToAgentFileHandler.cs
@@ -110,6 +110,7 @@ public class AttachToAgentFileHandler : BaseHandler
 
             file.AddAgent(agent);
             file.Resume = aiResponse.Value.Resume;
+            file.GeneratedName = aiResponse.Value.FileName;
             shouldPersist = true;
         }
 

--- a/Backend Dotnet API/src/Application/Handlers/File/Create/CreateFileHandler.cs
+++ b/Backend Dotnet API/src/Application/Handlers/File/Create/CreateFileHandler.cs
@@ -6,6 +6,7 @@ using Domain.Enums;
 using Domain.Errors;
 using ErrorOr;
 using System;
+using System.IO;
 
 namespace Application.Handlers.File.Create;
 
@@ -15,17 +16,20 @@ public class CreateFileHandler : BaseHandler
     private readonly IModuleService _moduleService;
     private readonly IFileUploadService _fileUploadService;
     private readonly IFileRepository _fileRepository;
+    private readonly IGemelliAIService _gemelliAIService;
 
     public CreateFileHandler(
         IAuthenticationService authenticationService,
         IModuleService moduleService,
         IFileUploadService fileUploadService,
-        IFileRepository fileRepository)
+        IFileRepository fileRepository,
+        IGemelliAIService gemelliAIService)
     {
         _authenticationService = authenticationService;
         _moduleService = moduleService;
         _fileUploadService = fileUploadService;
         _fileRepository = fileRepository;
+        _gemelliAIService = gemelliAIService;
     }
 
     public async Task<ErrorOr<FileResponseModel>> Handle(CreateFileRequest request, Module module, CancellationToken cancellationToken)
@@ -61,12 +65,30 @@ public class CreateFileHandler : BaseHandler
             return FileErrors.UploadFail;
         }
 
+        string? generatedName = null;
+        string? resume = null;
+
+        await using Stream summaryStream = request.Arquivo.OpenReadStream();
+
+        ErrorOr<GemelliAIFileResponse> summaryResult = await _gemelliAIService.SummarizeFileAsync(
+            summaryStream,
+            request.Arquivo.FileName,
+            request.Arquivo.ContentType ?? "application/octet-stream",
+            cancellationToken);
+
+        if (!summaryResult.IsError)
+        {
+            generatedName = summaryResult.Value.FileName;
+            resume = summaryResult.Value.Resume;
+        }
+
         await _fileRepository.AddAsync(new Domain.Entities.File()
         {
             Id = fileId,
             FileName = arquivo.Value.Name!,
             Module = module,
-            Resume = null,
+            GeneratedName = generatedName,
+            Resume = resume,
         }, cancellationToken);
         await _fileRepository.UnitOfWork.Commit();
 

--- a/Backend Dotnet API/src/Application/Interfaces/Services/IGemelliAIService.cs
+++ b/Backend Dotnet API/src/Application/Interfaces/Services/IGemelliAIService.cs
@@ -20,6 +20,12 @@ public interface IGemelliAIService
         GemelliAIFileRequest request,
         CancellationToken cancellationToken = default);
 
+    Task<ErrorOr<GemelliAIFileResponse>> SummarizeFileAsync(
+        Stream fileStream,
+        string fileName,
+        string contentType,
+        CancellationToken cancellationToken = default);
+
     Task<ErrorOr<bool>> DeleteFileAsync(
         string organization,
         string idAgent,

--- a/Backend Dotnet API/src/Domain/Entities/File.cs
+++ b/Backend Dotnet API/src/Domain/Entities/File.cs
@@ -6,6 +6,7 @@ public sealed class File : BaseEntity
 {
     public Module Module { get; set; }
     public string FileName { get; set; }
+    public string? GeneratedName { get; set; }
     public string? Resume { get; set; }
     public int? CompletionTokens { get; set; }
     public int? PromptTokens { get; set; }

--- a/Backend Dotnet API/src/Infrastructure/Contracts/GemelliAI/Response/FileSummaryResponse.cs
+++ b/Backend Dotnet API/src/Infrastructure/Contracts/GemelliAI/Response/FileSummaryResponse.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace Infrastructure.Contracts.GemelliAI.Response;
+
+public class FileSummaryResponse
+{
+    [JsonPropertyName("file_name")]
+    public string FileName { get; set; } = string.Empty;
+
+    [JsonPropertyName("resume")]
+    public string Resume { get; set; } = string.Empty;
+}

--- a/Backend Dotnet API/src/Infrastructure/HttpClient/GemelliAI/IGemelliAIClient.cs
+++ b/Backend Dotnet API/src/Infrastructure/HttpClient/GemelliAI/IGemelliAIClient.cs
@@ -31,4 +31,10 @@ public interface IGemelliAIClient
         string id_agent,
         string id_file,
         CancellationToken cancellationToken = default);
+
+    [Multipart]
+    [Post("/file/summary")]
+    Task<FileSummaryResponse> SummarizeFileAsync(
+        [AliasAs("file")] StreamPart file,
+        CancellationToken cancellationToken = default);
 }

--- a/Backend Dotnet API/src/Infrastructure/Migrations/Tenant/20251002000000_AddFileGeneratedName.Designer.cs
+++ b/Backend Dotnet API/src/Infrastructure/Migrations/Tenant/20251002000000_AddFileGeneratedName.Designer.cs
@@ -4,6 +4,7 @@ using Infrastructure.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Infrastructure.Migrations.Tenant
 {
     [DbContext(typeof(TenantDbContext))]
-    partial class TenantDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251002000000_AddFileGeneratedName")]
+    partial class AddFileGeneratedName
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Backend Dotnet API/src/Infrastructure/Migrations/Tenant/20251002000000_AddFileGeneratedName.cs
+++ b/Backend Dotnet API/src/Infrastructure/Migrations/Tenant/20251002000000_AddFileGeneratedName.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations.Tenant;
+
+/// <inheritdoc />
+public partial class AddFileGeneratedName : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<string>(
+            name: "GeneratedName",
+            table: "File",
+            type: "varchar(400)",
+            unicode: false,
+            maxLength: 1000,
+            nullable: true)
+            .Annotation("MySql:CharSet", "utf8mb4");
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "GeneratedName",
+            table: "File");
+    }
+}

--- a/Backend Dotnet API/src/Infrastructure/ModelConfig/Tenant/FileEntityConfig.cs
+++ b/Backend Dotnet API/src/Infrastructure/ModelConfig/Tenant/FileEntityConfig.cs
@@ -24,6 +24,10 @@ public sealed class FileConfiguration : IEntityTypeConfiguration<FileEntity>
             .IsRequired()
             .HasMaxLength(1000);
 
+        builder.Property(x => x.GeneratedName)
+            .IsRequired(false)
+            .HasMaxLength(1000);
+
         builder.Property(x => x.CompletionTokens)
             .IsRequired(false);
 


### PR DESCRIPTION
## Summary
- add FileSummaryResponse contract and Refit endpoint for the Gemelli AI file summary API
- expose SummarizeFileAsync in the Gemelli AI service and invoke it during file creation to persist generated metadata
- extend the File entity/schema with a GeneratedName column and surface the field via DTO mapping

## Testing
- not run (dotnet CLI unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e4135f61b08329aeeeda4a1871a00e