### PR TITLE
Update Qdrant collection naming to include agent and file

### DIFF
--- a/Backend Python API/src/application/chat_service.py
+++ b/Backend Python API/src/application/chat_service.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 from langchain.schema import AIMessage, HumanMessage
  
 from ..domain.chat import ChatRequest, ChatResponse, UserInfo, AgentState, Document
+from ..infrastructure.qdrant.naming import format_collection_name
 from ..infrastructure.usage_callback import UsageCallback
 from .agents.agent_graph import graph_builder
 from ..infrastructure.checkpointer import create_async_mysql_checkpointer
@@ -45,9 +46,16 @@ class ChatService:
         )
 
         if request.documents is not None:
+            collection_name = ""
+            if request.documents:
+                try:
+                    collection_name = format_collection_name(request.id_agent, request.documents[0])
+                except ValueError:
+                    collection_name = ""
+
             doc = Document(
                 tenant_id=request.organization,
-                collection_name=request.id_agent,
+                collection_name=collection_name,
                 id_file=request.documents
             )
         else:

--- a/Backend Python API/src/infrastructure/qdrant/naming.py
+++ b/Backend Python API/src/infrastructure/qdrant/naming.py
@@ -1,0 +1,19 @@
+"""Utility helpers for constructing Qdrant collection identifiers."""
+
+
+def format_collection_name(id_agent: str, id_file: str) -> str:
+    """Builds a normalized collection name using the agent and file identifiers."""
+
+    def _normalize(value: str) -> str:
+        return value.strip().replace(" ", "_").lower()
+
+    normalized_parts = [
+        _normalize(part)
+        for part in (id_agent, id_file)
+        if part and part.strip()
+    ]
+
+    if len(normalized_parts) != 2:
+        raise ValueError("Both id_agent and id_file must be provided to format the collection name.")
+
+    return "_".join(normalized_parts)


### PR DESCRIPTION
## Summary
- add a helper to normalize Qdrant collection names using the agent and file identifiers
- update file ingestion, deletion, and chat document wiring to use the new collection naming

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e42f066cf48329a2cf44bf5fac1c37