### PR TITLE
Fix null handling in Gemelli services

### DIFF
--- a/Backend Dotnet API/src/Application/Handlers/File/AttachToAgent/AttachToAgentFileHandler.cs
+++ b/Backend Dotnet API/src/Application/Handlers/File/AttachToAgent/AttachToAgentFileHandler.cs
@@ -70,12 +70,9 @@ public class AttachToAgentFileHandler : BaseHandler
             return AgentErrors.AgentNotFound;
         }
 
-        bool shouldPersist = false;
-
         if (file.HasAgent(request.IdAgent))
         {
             file.RemoveAgent(agent.Id);
-            shouldPersist = true;
         }
         else
         {
@@ -111,14 +108,10 @@ public class AttachToAgentFileHandler : BaseHandler
             file.AddAgent(agent);
             file.Resume = aiResponse.Value.Resume;
             file.GeneratedName = aiResponse.Value.FileName;
-            shouldPersist = true;
         }
 
-        if (shouldPersist)
-        {
-            _fileRepository.Update(file);
-            await _fileRepository.UnitOfWork.Commit();
-        }
+        _fileRepository.Update(file);
+        await _fileRepository.UnitOfWork.Commit();
 
         FileResponse fileResponse = file.Adapt<FileResponse>();
         return fileResponse;

--- a/Backend Dotnet API/src/Infrastructure/Services/GemelliAIService.cs
+++ b/Backend Dotnet API/src/Infrastructure/Services/GemelliAIService.cs
@@ -171,8 +171,9 @@ public class GemelliAIService : IGemelliAIService
 
             if (!deletionSucceeded)
             {
-                string message = !string.IsNullOrWhiteSpace(response?.Message)
-                    ? response!.Message
+                string? responseMessage = response?.Message;
+                string message = !string.IsNullOrWhiteSpace(responseMessage)
+                    ? responseMessage
                     : "Falha ao deletar arquivo na IA.";
 
                 return Error.Failure("IA.File.Delete.Error", message);


### PR DESCRIPTION
## Summary
- prevent possible null dereference when building delete failure messages in the Gemelli AI service
- simplify the attach-to-agent handler by removing an always-true persistence guard

## Testing
- Not run (dotnet CLI not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e489ea94f88329945b34e5fb6e5e03