### PR TITLE
Handle updated AI delete response

### DIFF
--- a/Backend Dotnet API/src/Infrastructure/Contracts/GemelliAI/Response/FileDeletionResponse.cs
+++ b/Backend Dotnet API/src/Infrastructure/Contracts/GemelliAI/Response/FileDeletionResponse.cs
@@ -10,6 +10,15 @@ public class FileDeletionResponse
     [JsonPropertyName("deleted")]
     public bool Deleted { get; set; }
 
+    [JsonPropertyName("status")]
+    public string Status { get; set; } = string.Empty;
+
+    [JsonPropertyName("deleted_count")]
+    public int DeletedCount { get; set; }
+
+    [JsonPropertyName("operation_id")]
+    public string? OperationId { get; set; }
+
     [JsonPropertyName("file_info")]
     public FileInfoResponse? FileInfo { get; set; }
 

--- a/Backend Dotnet API/src/Infrastructure/Services/GemelliAIService.cs
+++ b/Backend Dotnet API/src/Infrastructure/Services/GemelliAIService.cs
@@ -5,6 +5,7 @@ using Infrastructure.Contracts.GemelliAI.Response;
 using Infrastructure.HttpClient.GemelliAI;
 using Microsoft.Extensions.Logging;
 using Refit;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.IO;
@@ -168,9 +169,13 @@ public class GemelliAIService : IGemelliAIService
                 cancellationToken
             );
 
-            if (response is { Deleted: false } failedResponse)
+            bool isDeleted = response.Deleted
+                || string.Equals(response.Status, "ok", StringComparison.OrdinalIgnoreCase)
+                || response.DeletedCount > 0;
+
+            if (!isDeleted)
             {
-                string responseMessage = failedResponse.Message;
+                string responseMessage = response.Message;
                 string message = string.IsNullOrWhiteSpace(responseMessage)
                     ? "Falha ao deletar arquivo na IA."
                     : responseMessage;


### PR DESCRIPTION
## Summary
- align the Gemelli AI file deletion contract with the latest API response schema
- treat deletion as successful when the AI reports status ok or deleted vectors

## Testing
- dotnet test *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4eb7e2cb0832998959b78236425b9