### PR TITLE
feat: show generated file names and summaries

### DIFF
--- a/Frontend nextjs/src/app/(app)/agents/[id]/chat/_components/file-list.tsx
+++ b/Frontend nextjs/src/app/(app)/agents/[id]/chat/_components/file-list.tsx
@@ -94,6 +94,7 @@ export function FileList({ files, agentId, onFilesChanged }: FileListProps) {
       </div>
       <div className="flex-1 overflow-y-auto space-y-1 p-2">
         {files?.map((file) => {
+          const displayName = file.generatedName?.trim() || file.fileName;
           const ext = file.fileName.split(".").pop()?.toLowerCase() ?? "";
           const isImage = ["jpg", "jpeg", "png", "gif", "webp"].includes(ext);
           const isPdf = ext === "pdf";
@@ -103,7 +104,7 @@ export function FileList({ files, agentId, onFilesChanged }: FileListProps) {
           return (
             <div
               key={file.id}
-              className="relative bg-sidebar hover:bg-sidebar/80 border border-blue-300/20 shadow-md text-white rounded-lg hover:shadow-lg transition flex flex-col items-center justify-between p-4 h-24 cursor-pointer"
+              className="relative bg-sidebar hover:bg-sidebar/80 border border-blue-300/20 shadow-md text-white rounded-lg hover:shadow-lg transition flex flex-col items-center justify-between p-4 min-h-[7.5rem] cursor-pointer"
               onClick={() => {
                 setSelectedFileId(file.id);
                 setDialogOpen(true);
@@ -132,17 +133,30 @@ export function FileList({ files, agentId, onFilesChanged }: FileListProps) {
                     ? "/images/xlsx.png"
                     : "/images/file.png"
                 }
-                alt={file.fileName}
+                alt={displayName}
                 width={32}
                 height={32}
                 className="object-contain"
               />
               <p
                 className="text-[12px] font-medium text-center truncate w-full"
-                title={file.fileName}
+                title={displayName}
               >
-                {file.fileName}
+                {displayName}
               </p>
+              {file.resume && (
+                <p
+                  className="mt-1 text-[11px] text-center text-white/80 overflow-hidden w-full"
+                  style={{
+                    display: "-webkit-box",
+                    WebkitLineClamp: 2,
+                    WebkitBoxOrient: "vertical",
+                  }}
+                  title={file.resume}
+                >
+                  {file.resume}
+                </p>
+              )}
             </div>
           );
         })}

--- a/Frontend nextjs/src/app/(app)/files/_components/file-details.tsx
+++ b/Frontend nextjs/src/app/(app)/files/_components/file-details.tsx
@@ -30,6 +30,8 @@ export function FileDetails({ fileId, onBack, onDeleted }: FileDetailsProps) {
   if (isError) return <ErrorState error={error} />;
   if (!fileData) return null;
 
+  const displayName = fileData.generatedName?.trim() || fileData.fileName;
+
   const openUrl = fileData.urlFile
     ? buildFrontFileUrl(fileData.urlFile, fileData.fileName, { download: false })
     : null;
@@ -59,6 +61,11 @@ export function FileDetails({ fileId, onBack, onDeleted }: FileDetailsProps) {
         <p>
           <span className="font-medium">Nome:</span> {fileData.fileName}
         </p>
+        {fileData.generatedName && fileData.generatedName !== fileData.fileName && (
+          <p>
+            <span className="font-medium">Nome gerado:</span> {displayName}
+          </p>
+        )}
         <p>
           <span className="font-medium">Tipo:</span> {fileData.mimeType ?? "N/A"}
         </p>
@@ -70,6 +77,14 @@ export function FileDetails({ fileId, onBack, onDeleted }: FileDetailsProps) {
           <span className="font-medium">Enviado em:</span>{" "}
           {fileData.uploadedAt ? new Date(fileData.uploadedAt).toLocaleString() : "N/A"}
         </p>
+        {fileData.resume && (
+          <div>
+            <span className="font-medium">Resumo:</span>
+            <p className="mt-1 text-sm text-foreground/80 whitespace-pre-line">
+              {fileData.resume}
+            </p>
+          </div>
+        )}
       </div>
 
       <div className="flex gap-2">

--- a/Frontend nextjs/src/app/(app)/files/_components/file-list.tsx
+++ b/Frontend nextjs/src/app/(app)/files/_components/file-list.tsx
@@ -21,7 +21,7 @@ export function FileList({
     <div className="space-y-6">
       <div className="grid grid-cols-2 md:grid-cols-2 lg:grid-cols-3 gap-4">
         <div
-          className="bg-sidebar hover:bg-sidebar/80 text-white rounded-lg shadow hover:shadow-lg transition flex flex-col items-center justify-center p-4 h-32 cursor-pointer"
+          className="bg-sidebar hover:bg-sidebar/80 text-white rounded-lg shadow hover:shadow-lg transition flex flex-col items-center justify-center p-4 min-h-[9rem] cursor-pointer"
           onClick={onNew}
         >
           <span className="text-2xl font-bold">+</span>
@@ -29,6 +29,7 @@ export function FileList({
         </div>
 
         {files.itens.map((file) => {
+          const displayName = file.generatedName?.trim() || file.fileName;
           const ext = file.fileName.split(".").pop()?.toLowerCase() ?? "";
           const isImage = ["jpg", "jpeg", "png", "gif", "webp"].includes(ext);
           const isPdf = ext === "pdf";
@@ -38,7 +39,7 @@ export function FileList({
           return (
             <div
               key={file.id}
-              className="bg-sidebar hover:bg-sidebar/80 border border-blue-300/20 shadow-md text-white rounded-lg hover:shadow-lg transition flex flex-col items-center justify-between p-4 h-32 cursor-pointer relative"
+              className="bg-sidebar hover:bg-sidebar/80 border border-blue-300/20 shadow-md text-white rounded-lg hover:shadow-lg transition flex flex-col items-center justify-between p-4 min-h-[9rem] cursor-pointer relative"
               onClick={() => onSelectFile?.(file.id)}
             >
               <Image
@@ -53,7 +54,7 @@ export function FileList({
                     ? "/images/xlsx.png"
                     : "/images/file.png"
                 }
-                alt={file.fileName}
+                alt={displayName}
                 width={32}
                 height={32}
                 className="object-contain"
@@ -61,10 +62,23 @@ export function FileList({
 
               <p
                 className="text-[12px] font-medium text-center truncate w-full"
-                title={file.fileName}
+                title={displayName}
               >
-                {file.fileName}
+                {displayName}
               </p>
+              {file.resume && (
+                <p
+                  className="mt-1 text-[11px] text-center text-white/80 overflow-hidden w-full"
+                  style={{
+                    display: "-webkit-box",
+                    WebkitLineClamp: 2,
+                    WebkitBoxOrient: "vertical",
+                  }}
+                  title={file.resume}
+                >
+                  {file.resume}
+                </p>
+              )}
             </div>
           );
         })}

--- a/Frontend nextjs/src/types/schemas/file.schema.ts
+++ b/Frontend nextjs/src/types/schemas/file.schema.ts
@@ -4,11 +4,13 @@ import { z } from "zod";
 export const FileSchema = z.object({
   id: z.string().uuid(),
   fileName: z.string().min(1, "Nome do arquivo é obrigatório"),
+  generatedName: z.string().min(1).nullable().optional(),
   urlFile: z.string().nullable(),
   fileSize: z.number().optional(),
   mimeType: z.string().optional(),
   uploadedAt: z.string().datetime().optional(),
   idAgent: z.string().uuid().optional(),
+  resume: z.string().min(1).nullable().optional(),
 });
 
 export const UploadResultSchema = z.object({


### PR DESCRIPTION
## Summary
- display AI generated file names in the files grid and agent file picker
- surface file summaries within list cards and file details view
- extend file schema typing with generatedName and resume properties

## Testing
- npm run lint *(fails: missing @eslint/eslintrc package)*

------
https://chatgpt.com/codex/tasks/task_e_68e4eca04b6083298fc0fdc0395dd214