### PR TITLE
Handle null file pages in schema

### DIFF
--- a/Frontend nextjs/src/types/schemas/file.schema.ts
+++ b/Frontend nextjs/src/types/schemas/file.schema.ts
@@ -27,7 +27,10 @@ export const AgentSchema = z.object({
 });
 
 export const FileWithRelationsSchema = FileSchema.extend({
-  pages: z.array(z.any()),
+  pages: z
+    .array(z.any())
+    .nullable()
+    .transform((pages) => pages ?? []),
   agents: z.array(AgentSchema),
 });
 


### PR DESCRIPTION
## Summary
- allow file relation pages to be null from the API and normalize them to an empty array

## Testing
- npm run lint *(fails: missing @eslint/eslintrc package)*

------
https://chatgpt.com/codex/tasks/task_e_68e4eee182c48329a0b3b734f4a25d60