### PR TITLE
Handle null file pages when parsing agent details

### DIFF
--- a/Frontend nextjs/src/types/schemas/agent.schema.ts
+++ b/Frontend nextjs/src/types/schemas/agent.schema.ts
@@ -20,7 +20,10 @@ export const PageSchema = z.object({
 });
 
 export const FileWithPagesSchema = FileSchema.extend({
-  pages: z.array(PageSchema),
+  pages: z
+    .array(PageSchema)
+    .nullable()
+    .transform((pages) => pages ?? []),
 });
 
 export const ChatSessionSchema = z.object({


### PR DESCRIPTION
## Summary
- allow agent file page parsing to accept null values by normalizing them to an empty array

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68e4f08c767483298442efd23f13a0c0