### PR TITLE
Fix culture-specific string conversion in file upload

### DIFF
--- a/Backend Dotnet API/src/Infrastructure/Services/FileUploadService.cs
+++ b/Backend Dotnet API/src/Infrastructure/Services/FileUploadService.cs
@@ -7,6 +7,7 @@ using Application.Interfaces.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Azure.Storage.Sas;
+using System.Globalization;
 using System.IO;
 
 namespace Infrastructure.Services;
@@ -103,7 +104,7 @@ public class FileUploadService : IFileUploadService
         int duplicateCounter = 1;
         while (await createClient.ExistsAsync(cancellationToken))
         {
-            string suffix = duplicateCounter.ToString();
+            string suffix = duplicateCounter.ToString(CultureInfo.InvariantCulture);
             fileNameToUse = string.IsNullOrEmpty(fileNameWithoutExtension)
                 ? $"{suffix}{extension}"
                 : $"{fileNameWithoutExtension}_{suffix}{extension}";


### PR DESCRIPTION
## Summary
- use CultureInfo.InvariantCulture when building duplicate filename suffixes
- add the missing CultureInfo import to support the new usage

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e4f23079448329935958ff89f7d4b7