### PR TITLE
Add frontend support for detaching files from agents

### DIFF
--- a/Frontend nextjs/src/app/(app)/agents/[id]/chat/_components/file-list.tsx
+++ b/Frontend nextjs/src/app/(app)/agents/[id]/chat/_components/file-list.tsx
@@ -10,7 +10,7 @@ import { FileDetails } from "../../../../files/_components/file-details";
 import { FileList as SelectFileList } from "../../../../files/_components/file-list";
 import { UploadForm } from "../../../../files/_components/upload-form";
 import { useFilesPage } from "../../../../files/_hooks/use-files-page.hook";
-import { attachFileToAgent } from "@/lib/api/file.client";
+import { attachFileToAgent, detachFileFromAgent } from "@/lib/api/file.client";
 import { toast } from "sonner";
 
 interface FileListProps {
@@ -42,16 +42,24 @@ export function FileList({ files, agentId, onFilesChanged }: FileListProps) {
     handleDrop,
   } = useFilesPage();
 
-  const handleAttachFile = async (fileId: string, desanexar = false) => {
+  const handleAttachFile = async (fileId: string) => {
     try {
       await attachFileToAgent(fileId, { idAgent: agentId });
-      toast.success(
-        `Arquivo ${desanexar ? "desanexado do" : "anexado ao"} agente!`
-      );
+      toast.success("Arquivo anexado ao agente!");
       onFilesChanged?.();
       setAddDialogOpen(false);
     } catch (err) {
       toast.error("Erro ao anexar arquivo: " + err);
+    }
+  };
+
+  const handleDetachFile = async (fileId: string) => {
+    try {
+      await detachFileFromAgent(fileId, agentId);
+      toast.success("Arquivo desanexado do agente!");
+      onFilesChanged?.();
+    } catch (err) {
+      toast.error("Erro ao desanexar arquivo: " + err);
     }
   };
 
@@ -115,7 +123,7 @@ export function FileList({ files, agentId, onFilesChanged }: FileListProps) {
                 className="absolute top-2 right-2 text-red-400 hover:text-red-600"
                 onClick={(e) => {
                   e.stopPropagation();
-                  handleAttachFile(file.id, true);
+                  handleDetachFile(file.id);
                 }}
                 title="Desanexar"
               >

--- a/Frontend nextjs/src/app/api/file/[id]/attach/[agentId]/route.ts
+++ b/Frontend nextjs/src/app/api/file/[id]/attach/[agentId]/route.ts
@@ -1,0 +1,29 @@
+// src\app\api\file\[id]\attach\[agentId]\route.ts
+import { NextRequest, NextResponse } from "next/server";
+import serverFetch from "@/lib/fetch/server.fetch";
+import { handleApiError } from "@/lib/utils/api-error-handler.utils";
+
+export async function DELETE(
+  req: NextRequest,
+  context: { params: Promise<{ id: string; agentId: string }> }
+) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const currentModule = searchParams.get("module");
+
+    if (!currentModule) {
+      return NextResponse.json({ error: "Module é obrigatório" }, { status: 400 });
+    }
+
+    const { id, agentId } = await context.params;
+
+    await serverFetch<void>(
+      `/api/${currentModule}/file/${id}/attach/${agentId}`,
+      "DELETE"
+    );
+
+    return NextResponse.json(null, { status: 200 });
+  } catch (err) {
+    return handleApiError(err);
+  }
+}

--- a/Frontend nextjs/src/lib/api/file.client.ts
+++ b/Frontend nextjs/src/lib/api/file.client.ts
@@ -108,3 +108,7 @@ export async function attachFileToAgent(
 ) {
   await fetchFileClient(`/${id}/attach`, "PUT", payload);
 }
+
+export async function detachFileFromAgent(fileId: string, agentId: string) {
+  await fetchFileClient(`/${fileId}/attach/${agentId}`, "DELETE");
+}


### PR DESCRIPTION
## Summary
- add a Next.js API route that proxies file detach requests to the backend service
- expose a client helper for detaching files from agents and use it in the chat file list

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4f64686788329beb921f13c95c688